### PR TITLE
Write 128 or the size of the whole model, whichever is smaller.

### DIFF
--- a/Vox/VoxWriter.cs
+++ b/Vox/VoxWriter.cs
@@ -173,9 +173,9 @@ namespace FileToVoxCore.Vox
 			writer.Write(12); //Chunk Size (constant)
 			writer.Write(0); //Child Chunk Size (constant)
 
-			writer.Write(Schematic.CHUNK_SIZE); //Width
-			writer.Write(Schematic.CHUNK_SIZE); //Height
-			writer.Write(Schematic.CHUNK_SIZE); //Depth
+			writer.Write(Math.Min(Schematic.CHUNK_SIZE, mSchematic.Width)); //Width
+			writer.Write(Math.Min(Schematic.CHUNK_SIZE, mSchematic.Height)); //Height
+			writer.Write(Math.Min(Schematic.CHUNK_SIZE, mSchematic.Length)); //Depth
 		}
 
 		/// <summary>


### PR DESCRIPTION
Fixes https://github.com/Zarbuz/FileToVoxCore/issues/2